### PR TITLE
implements attr reader for can_create_news_items attribute 

### DIFF
--- a/infopark_rails_connector_meta/app/models/rails_connector/obj_class.rb
+++ b/infopark_rails_connector_meta/app/models/rails_connector/obj_class.rb
@@ -25,6 +25,12 @@ module RailsConnector
       @blob_data['titles'] || {}
     end
 
+    # returns channel feature is_activate?
+    def can_create_news_items?
+      load_blob_data
+      @blob_data['canCreateNewsItems'].to_i != 0
+    end
+
     # Returns the custom Ruby class or RailsConnector::AbstractObj.
     def ruby_class
       # this must be the same algorithm that the rest of the RailsConnector uses!


### PR DESCRIPTION
... for obj_classes
- Now we can check, if the obj_class allows can_create_news_items.
