### PR TITLE
Login by Rails session

### DIFF
--- a/infopark_reactor/lib/engine.rb
+++ b/infopark_reactor/lib/engine.rb
@@ -24,6 +24,11 @@ module Reactor
           Rails.logger.info "Trying to log in at #{Reactor::Configuration.xml_access[:host]}:#{Reactor::Configuration.xml_access[:port]} with JSESSIONID=#{jsessionid}."
           rsession.login(jsessionid)
           Rails.logger.info %|Logged in as "#{rsession.user_name}".| if rsession.user?
+            
+        elsif (session_var = Reactor::Configuration.xml_access[:trusted_session_var]).present? && session[session_var].present?
+          Rails.logger.info "** Using trusted session var \"#{session_var}\": #{session[session_var]}"
+          rsession.login_with_session_var(session[session_var], session[:session_id])
+          Rails.logger.info %|Logged in as "#{rsession.user_name}".| if rsession.user?
         else
           rsession.destroy
         end

--- a/infopark_reactor/lib/reactor/session.rb
+++ b/infopark_reactor/lib/reactor/session.rb
@@ -15,6 +15,13 @@ class Reactor::Session
       self.user_name = authenticate(session_id)
     end
   end
+  
+  def login_with_session_var(login, session_id)
+    if !logged_in?(session_id)
+      self.user_name = login
+      self.session_id = session_id
+    end
+  end
 
   def destroy
     self.session_id = self.user_name = nil


### PR DESCRIPTION
This modification allows login to CM by a trusted session variable
containing the login name. Make sure to add the following to
initializers/reactor.rb:
:trusted_session_var => 'login' # name of session variable with trusted login name (or nil)

Use case:
- User is not logged in to Fiona GUI but on live site
- Live site uses same user repository as CM to make sure login names match

Note:
- Login is not double checked
