### PR TITLE
adjust fiona connector override

### DIFF
--- a/infopark_reactor/app/models/rails_connector/abstract_obj.rb
+++ b/infopark_reactor/app/models/rails_connector/abstract_obj.rb
@@ -25,7 +25,7 @@ module RailsConnector
 
   class AbstractObj
     def self.compute_type(type_name)
-      try_type { type_name.constantize } || self 
+      try_type { type_name.safe_constantize } || self
     end
   end
 end


### PR DESCRIPTION
Since reactor overrides `try_type` method from infopark_fiona_connector
it should also respect changes from PR to the infopark fiona connector https://github.com/infopark/fiona_connector/pull/18